### PR TITLE
Fixes #12955

### DIFF
--- a/code/WorkInProgress/SpyGuyStuff.dm
+++ b/code/WorkInProgress/SpyGuyStuff.dm
@@ -1018,7 +1018,7 @@ proc/Create_Tommyname()
 
 	proc/check_conditions()
 		. = 0
-		if(BOUNDS_DIST(owner, target) > 0 || !target || !owner || !the_garrote || !the_garrote.wire_readied)
+		if(BOUNDS_DIST(owner, target) > 0 || !isturf(target.loc) || !target || !owner || !the_garrote || !the_garrote.wire_readied)
 			interrupt(INTERRUPT_ALWAYS)
 			. = 1
 


### PR DESCRIPTION
Adds a check for the garrote to make sure the target is on the same turf as the one garrote-ing them